### PR TITLE
 To find out the status of a specific appointment

### DIFF
--- a/src/main/java/com/eldencare/appoimentsystem/entity/AppointmentStatus.java
+++ b/src/main/java/com/eldencare/appoimentsystem/entity/AppointmentStatus.java
@@ -1,0 +1,11 @@
+package com.eldencare.appoimentsystem.entity;
+
+public enum AppointmentStatus {
+
+    REQUESTED,   // Patient requested an appointment
+    BOOKED,      // Confirmed by doctor/system
+    COMPLETED,   // Appointment took place successfully after payment successfull
+    CANCELLED,   // Cancelled by patient or doctor
+    PENDING,     // Waiting for approval/confirmation
+    DECLINED     // Doctor rejected request
+}


### PR DESCRIPTION
An "appointment status" refers to the current state of an appointment, which can vary based on the system it's in